### PR TITLE
Lines and Ramps

### DIFF
--- a/minigolf/level-data.js
+++ b/minigolf/level-data.js
@@ -4,6 +4,10 @@ var levelData = [
         holePosition: [250, 75],
         area: `
             ADD rect 0, 0, 300, 150;
+            // HEIGHT + 2: ramp 100, 100, 200, 50, 20;
+            // HEIGHT = -1: line 50, 20, 100, 30, 10;
+            // HEIGHT = 01134: line 20, 110, 100, 130, 20;
+            // HEIGHT = 843: line 250, 20, 220, 140, 30;
         `,
         obstacles: `
         `,
@@ -131,11 +135,11 @@ var levelData = [
             ADD rect 113, 110, 75, 75;
 
             // Bottom section;
-            ADD rect 0, 400, 300, 50; 
+            ADD rect 0, 400, 300, 50;
 
         `,
         obstacles: `
-        
+
             ADD Tubes 275 25 25 225;
             ADD Tubes 275 225 25 425;
             ADD Sandtrap 150 3 100 50;
@@ -149,7 +153,7 @@ var levelData = [
         ballPosition: [-130,50],
         holePosition: [150,50],
         area: `
-            
+
                 // Outside ring;
                 ADD circ 150, 50, 300;
                 SUB circ 150, 50, 250;
@@ -162,12 +166,12 @@ var levelData = [
                 ADD rect 225, 0, 100, 100;
                 // hole circle;
                 ADD circ 150, 50, 100;
-             
+
         `,
         obstacles: `
             ADD Sandtrap 80 50 10 50;
             // sandtrap is underneath tubeB, used to slow ball down so it enters hole;
-            ADD Tubes 425 50 75 50; 
+            ADD Tubes 425 50 75 50;
             ADD Windmill 150 -180;
             ADD Windmill 150 280;
         `,
@@ -203,7 +207,7 @@ var levelData = [
           // colum right above the ball by the circle portal;
           ADD Sandtrap 85 145 152 160;
           //the portals;
-          ADD Tubes 35 45 310 50; 
+          ADD Tubes 35 45 310 50;
         `,
         par: 3,
     },

--- a/minigolf/main.js
+++ b/minigolf/main.js
@@ -643,15 +643,15 @@ function drawPutter(){
 }
 
 function distanceSquaredToLineSegment(lx1, ly1, lx2, ly2, px, py) {
-   var ldx = lx2 - lx1,
+    var ldx = lx2 - lx1,
        ldy = ly2 - ly1,
        lineLengthSquared = ldx*ldx + ldy*ldy;
-   return distanceSquaredToLineSegment2(lx1, ly1, ldx, ldy, lineLengthSquared, px, py);
+    return distanceSquaredToLineSegment2(lx1, ly1, ldx, ldy, lineLengthSquared, px, py);
 }
 
 function distanceToLineSegment(lx1, ly1, lx2, ly2, px, py)
 {
-   return Math.sqrt(distanceSquaredToLineSegment(lx1, ly1, lx2, ly2, px, py));
+    return Math.sqrt(distanceSquaredToLineSegment(lx1, ly1, lx2, ly2, px, py));
 }
 
 async function drawPar() {

--- a/minigolf/terrain-shader.js
+++ b/minigolf/terrain-shader.js
@@ -86,6 +86,22 @@ float distanceToLineSegment(vec2 lineStart, vec2 lineEnd, vec2 point)
    return sqrt(distanceSquaredToLineSegment(lineStart.x, lineStart.y, lineEnd.x, lineEnd.y, point.x, point.y));
 }
 
+float projectAndLerp(vec2 A, vec2 B, vec2 P)
+{
+    vec2 a_to_p = P - A;
+    vec2 a_to_b = B - A;
+
+    float atb2 = a_to_b.x * a_to_b.x + a_to_b.y * a_to_b.y;
+
+    float atp_dot_atb = a_to_p.x * a_to_b.x + a_to_p.y * a_to_b.y;
+
+    float t = atp_dot_atb / atb2;
+
+    return t;
+
+    // return A + a_to_b * t;
+}
+
 float shapeHasPoint(int shapeType, vec4 shapeData, vec4 shapeData2, int grad, vec2 point)
 {
     if (shapeType == 0) // Oval
@@ -100,11 +116,15 @@ float shapeHasPoint(int shapeType, vec4 shapeData, vec4 shapeData2, int grad, ve
     }
     if (shapeType == 1) // Line
     {
-        float weight = (distanceToLineSegment(shapeData.xy, shapeData.zw, point.xy) < shapeData2.x) ? 1.0 : 0.0;
-        if (grad == 0)
-            return ceil(weight);
-        else
-            return weight;
+        float projection = projectAndLerp(shapeData.xy, shapeData.zw, point.xy);
+        if (distanceToLineSegment(shapeData.xy, shapeData.zw, point.xy) < shapeData2.x && projection > 0.0 && projection < 1.0)
+        {
+            if (grad == 0)
+                return 1.0;
+            else
+                return projection;
+        }
+        return 0.0;
     }
     if (shapeType == 2) // Rect
     {
@@ -151,7 +171,9 @@ void main( void )
     float pointHeight = getHeight(coords);
 	vec3 color;
     if ( pointHeight == SAND_HEIGHT )
-        pointHeight = getHeight(coords + mod(vec2(coords.y * coords.x) + floor(10.0 * coords.x / coords.y) , 5.0) * 0.5);
+        pointHeight = getHeight(coords + mod(vec2(coords.y * coords.x) + floor(10.0 * coords.x / coords.y), 5.0) * 0.5 * 1.0);
+        if ( pointHeight == SAND_HEIGHT )
+            pointHeight = getHeight(coords + mod(vec2(coords.y * coords.x) + floor(10.0 * coords.x / coords.y), 5.0) * 0.5 * -1.0);
 
     if ( pointHeight == SAND_HEIGHT )
     {


### PR DESCRIPTION
We can now make linear ramps and non-rectangular lines of terrain. Ramps higher than HEIGHT + 1 are generally too steep for the ball to get over.
```
// Ramp. Middle of screen;
HEIGHT + 1: ramp 100, 100, 200, 50, 20;

// Flat line with no gradient. Top left;
HEIGHT = -1: line 50, 20, 100, 30, 10;

// Sand. Bottom left;
HEIGHT = 01134: line 20, 110, 100, 130, 20;

// Water. Right;
HEIGHT = 843: line 250, 20, 220, 140, 30;
```
![image](https://github.com/user-attachments/assets/279fe764-154c-485e-83b5-39438f64130f)
